### PR TITLE
Disable author field in manifest

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -116,6 +116,7 @@ module.exports = {
 
   manifest: {
     name: 'Animeloop',
+    author: false,
     short_name: 'Animeloop',
     description: 'Animeloop Web Frontend',
     ogTitle: false,


### PR DESCRIPTION
If author exists, Telegram webpage preview will display the author as it is the page title.